### PR TITLE
feat: dicomweb dump for http and file locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+*.code-workspace
 
 # yarn v2
 .yarn/cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testdata"]
+	path = testdata
+	url = https://github.com/OHIF/viewer-testdata-dicomweb.git

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ dcmjs dump <part10file>
 
 ```
 # Example series retrieve/dump
-dicomwebjs dump dicomwebjs dump https://d33do7qe4w26qo.cloudfront.net/dicomweb/studies/1.3.6.1.4.1.14519.5.2.1.4792.2001.105216574054253895819671475627/series
+dicomwebjs dump https://d33do7qe4w26qo.cloudfront.net/dicomweb/studies/1.3.6.1.4.1.14519.5.2.1.4792.2001.105216574054253895819671475627/series
 # Example metadata retrieve/dump
 dicomwebjs dump https://d33do7qe4w26qo.cloudfront.net/dicomweb/studies/1.3.6.1.4.1.14519.5.2.1.4792.2001.105216574054253895819671475627/series/1.3.6.1.4.1.14519.5.2.1.4792.2001.323835191362867057104216682000/metadata
 
 # Example file retrieve
-dicomwebjs dump testdata/studies/1.2.276.1.74.1.2.132733202464108492637644434464108492\series\2.16.840.1.113883.3.8467.132733202477512857637644434477512857\metadata.gz
+dicomwebjs dump testdata/studies/1.2.276.1.74.1.2.132733202464108492637644434464108492/series/2.16.840.1.113883.3.8467.132733202477512857637644434477512857/metadata.gz
 ```
 
 ## File Locations

--- a/README.md
+++ b/README.md
@@ -15,3 +15,27 @@ yarn link:exec
 dcmjs dump <part10file>
 ```
 
+# dicomwebjs commands
+
+## dump `url`
+
+```
+# Example series retrieve/dump
+dicomwebjs dump dicomwebjs dump https://d33do7qe4w26qo.cloudfront.net/dicomweb/studies/1.3.6.1.4.1.14519.5.2.1.4792.2001.105216574054253895819671475627/series
+# Example metadata retrieve/dump
+dicomwebjs dump https://d33do7qe4w26qo.cloudfront.net/dicomweb/studies/1.3.6.1.4.1.14519.5.2.1.4792.2001.105216574054253895819671475627/series/1.3.6.1.4.1.14519.5.2.1.4792.2001.323835191362867057104216682000/metadata
+
+# Example file retrieve
+dicomwebjs dump testdata/studies/1.2.276.1.74.1.2.132733202464108492637644434464108492\series\2.16.840.1.113883.3.8467.132733202477512857637644434477512857\metadata.gz
+```
+
+## File Locations
+Files dicomweb can be paths to JSON files.  However, tree structure data must follow the Static DICOMweb format, specifically starting at `studies/` relative to the base directory, and containing some/all of the ones below.
+Note that un-compressed files are acceptable as well, but will not be found on a search.
+
+* `studies/index.json.gz` - an index in DICOMweb QIDO response format for the studies
+* `studies/<studyUID>/index.json.gz` - the index entry of this study
+* `studies/<studyUID>/series/index.json.gz` - the series QIDO response
+* `studies/<studyUID>/series/<seriesUID>/metadata.gz` - the metadata WADO response
+* `studies/<studyUID>/bulkdata/...` - bulkdata files
+* `studies/<studyUID>/series/<seriesUID>/instances/<instanceUID>/frame/<frameNumber>` - compressed frame data

--- a/bin/dicomwebjs.js
+++ b/bin/dicomwebjs.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { readDicomWeb, instanceDicom, dumpDicom } from '../src/index.js';
+import { dicomweb, instanceDicom, dumpDicom } from '../src/index.js';
 
 const program = new Command();
 
@@ -8,15 +8,16 @@ program
   .name('dicomwebjs')
   .description('dicomwebjs based tools for manipulation of DICOMweb')
   .version('0.0.1')
-  .options('--seriesUID <seriesUID>', 'For a specific seriesUID')
+  .option('--seriesUID <seriesUID>', 'For a specific seriesUID');
 
 program.command('dump')
   .description('Dump a dicomweb file')
   .argument('<dicomwebUrl>', 'dicomweb URL or file location')
-  // .option('-s, --separator <char>', 'separator character', ',')
-  .action(async (fileName, _options) => {
-    const dicomDict = readDicomWeb(fileName, options);
-    dumpDicom(dicomDict);
+  .action(async (fileName, options) => {
+    const qido = await dicomweb.readDicomWeb(fileName, options);
+    for (const dict of qido) {
+      dumpDicom({ dict });
+    }
   });
 
 program.command('instance')
@@ -24,8 +25,10 @@ program.command('instance')
   .argument('<part10>', 'part 10 file')
   .option('-p, --pretty', 'Pretty print')
   .action(async (fileName, options) => {
-    const dicomDict = readDicomWeb(fileName, options);
-    instanceDicom(dicomDict, options);
+    const qido = await dicomweb.readDicomWeb(fileName, options);
+    for (const dict of qido) {
+      instanceDicom({ dict }, options);
+    }
   })
 
 

--- a/src/dicomweb.js
+++ b/src/dicomweb.js
@@ -1,3 +1,6 @@
+import zlib from 'zlib';
+import fs from 'fs';
+
 import { httprequest } from './webRetrieve.js';
 
 export function readDicomWeb(url, options = {}) {
@@ -12,6 +15,10 @@ export function readDicomWebHttp(url, options) {
 }
 
 
-export function readDicomWebFile(url, options) {
-  throw new Error('TODO');
+export function readDicomWebFile(fileName, _options) {
+  const isGzip = fileName.endsWith('.gz');
+  const arrayBuffer = fs.readFileSync(fileName).buffer;
+  const uncompressed = isGzip ? zlib.gunzipSync(arrayBuffer) : arrayBuffer;
+  const str = uncompressed.toString();
+  return JSON.parse(str);
 }

--- a/src/dicomweb.js
+++ b/src/dicomweb.js
@@ -1,0 +1,17 @@
+import { httprequest } from './webRetrieve.js';
+
+export function readDicomWeb(url, options = {}) {
+  if (url.startsWith('http')) {
+    return readDicomWebHttp(url, options);
+  }
+  return readDicomWebFile(url, options);
+}
+
+export function readDicomWebHttp(url, options) {
+  return httprequest(url, options);
+}
+
+
+export function readDicomWebFile(url, options) {
+  throw new Error('TODO');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import fs from "fs";
 import dcmjs from "dcmjs";
 
+export * as dicomweb from './dicomweb.js';
+
 const { DicomMessage, DicomMetaDictionary } = dcmjs.data;
 
 export function readDicom(fileName) {

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,17 @@ export function dumpData(data, options, indent = '') {
 }
 
 export function valueToString(value, options) {
-  const { Value: values } = value;
+  const { Value: values, vr, InlineBinary, BulkDataURI } = value;
+  if (InlineBinary) {
+    return `Inline Binary ${InlineBinary.substring(0, Math.min(InlineBinary.length, 32))}${InlineBinary.length > 31 ? '...' : ''} (${InlineBinary.length * 3 / 4})`
+  }
+  if (BulkDataURI) {
+    return `URL ${BulkDataURI}`;
+  }
   if (!values) {
+    if (vr) {
+      return vr;
+    }
     console.log("***** Value = ", value);
     return '';
   }
@@ -57,13 +66,16 @@ export function valueToString(value, options) {
   if (typeof v0 === 'object') {
     return values.map(it => JSON.stringify(it)).join(', ');
   }
+  if (!Array.isArray(values)) {
+    return JSON.stringify(values);
+  }
   return values.map(it => String(it)).join(', ');
 }
 
 export function dumpSq(tag, value, options, indent) {
   const { Value: sq } = value;
   if (sq?.length === undefined) {
-    console.log("**** undefined value length", value);
+    console.log("Empty SQ");
     return;
   }
   for (let i = 0; i < sq.length; i++) {

--- a/src/webRetrieve.js
+++ b/src/webRetrieve.js
@@ -6,7 +6,8 @@ import zlib from 'zlib';
 export function httprequest(url, _options) {
   return new Promise((resolve, reject) => {
     const urlObj = URL.parse(url, true);
-    const httpType = urlObj.protocol === 'https' ? https : http;
+    const isHttps = urlObj.protocol === 'https:';
+    const httpType = isHttps ? https : http;
 
     const req = httpType.request(urlObj, (res) => {
       if (res.statusCode < 200 || res.statusCode >= 300) {

--- a/src/webRetrieve.js
+++ b/src/webRetrieve.js
@@ -1,0 +1,40 @@
+import https from 'https';
+import http from 'http';
+import URL from 'url';
+import zlib from 'zlib';
+
+export function httprequest(url, _options) {
+  return new Promise((resolve, reject) => {
+    const urlObj = URL.parse(url, true);
+    const httpType = urlObj.protocol === 'https' ? https : http;
+
+    const req = httpType.request(urlObj, (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        return reject(new Error('statusCode=' + res.statusCode));
+      }
+      const body = [];
+      res.on('data', function (chunk) {
+        body.push(chunk);
+      });
+      res.on('end', function () {
+        const contentEncoding = res.headers['content-encoding'];
+        try {
+          const buf = Buffer.concat(body);
+          const uncompressed = contentEncoding === 'gzip' ? zlib.gunzipSync(buf) : buf;
+          if (!uncompressed) {
+            return uncompressed;
+          }
+          const json = JSON.parse(uncompressed?.toString());
+          resolve(json);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    req.on('error', (e) => {
+      reject(e.message);
+    });
+    // send the request
+    req.end();
+  });
+}


### PR DESCRIPTION
Adds file locations to perform dumps on for http and file based URLs.  See the readme file for examples.